### PR TITLE
Add an account client mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,19 @@
-composer.phar
+.env
 dist/
 vendor/
+
+# Composer
+composer.phar
+/vendor/
+.php_cs.cache
+.php_cs
+install.lock
+composer-setup.php
+
+# Mac OS
+.DS_Store
+
+# Jetbrains
+.idea
+
+*.cache

--- a/config/common.yml
+++ b/config/common.yml
@@ -14,3 +14,7 @@ services:
   PrestaShop\Module\PsAccounts\Service\PsAccountsService:
     class: PrestaShop\Module\PsAccounts\Service\PsAccountsService
     public: true
+
+  PrestaShop\Module\PsAccounts\Api\Client\AccountsClient:
+    class: PrestaShop\Module\PsAccounts\Api\Client\AccountsClient
+    public: true

--- a/src/Api/Client/AccountsClient.php
+++ b/src/Api/Client/AccountsClient.php
@@ -1,0 +1,44 @@
+<?php
+namespace PrestaShop\Module\PsAccounts\Api\Client;
+
+/**
+ * Class ServicesAccountsClient mock
+ */
+class AccountsClient
+{
+    /**
+     * ServicesAccountsClient constructor.
+     */
+    public function __construct() {
+    }
+
+    /**
+     * Mock the original PS Accounts client
+     * @see https://github.com/PrestaShopCorp/ps_accounts/blob/master/src/Api/Client/AccountsClient.php#L221
+     * @return array response
+     */
+    public function verifyToken()
+    {
+      return [
+        "status" => true,
+        "httpCode" => 200,
+        "body" => null
+      ];
+    }
+
+    /**
+     * Mock the original RefreshShopToken 
+     * @see https://github.com/PrestaShopCorp/ps_accounts/blob/master/src/Api/Client/AccountsClient.php#L106C21-L106C37
+     * @return array response
+     */
+    public function refreshShopToken()
+    {
+      return [
+        "status" => false,
+        "httpCode" => 400,
+        "body"=> [
+          "message" => "Cannot refresh token"
+        ]        
+      ];
+    }
+}


### PR DESCRIPTION
ps_eventbus healthcheck is based on one of these methods, and in a mocked env the status was always unhealthy, due to the absence of this symfony service.