### PR TITLE
1.6 compatibility testing

### DIFF
--- a/ps_accounts.php
+++ b/ps_accounts.php
@@ -30,9 +30,9 @@ class Ps_accounts extends Module
 
         parent::__construct();
 
-        $this->displayName = $this->trans('PS Accounts Mock', [], 'Modules.Mymodule.Admin');
-        $this->description = $this->trans('Mocking', [], 'Modules.Mymodule.Admin');
-        $this->confirmUninstall = $this->trans('Are you sure you want to uninstall?', [], 'Modules.Mymodule.Admin');
+        $this->displayName = $this->l('PS Accounts Mock', [], 'Modules.Mymodule.Admin');
+        $this->description = $this->l('Mocking', [], 'Modules.Mymodule.Admin');
+        $this->confirmUninstall = $this->l('Are you sure you want to uninstall?', [], 'Modules.Mymodule.Admin');
 
         require_once __DIR__ . '/vendor/autoload.php';
 


### PR DESCRIPTION
Installing this module on a 1.6 store display these errors:
```
prestashop-1  |   Fatal error: Call to undefined method Ps_accounts::trans() in /var/www/html/modules/ps_accounts/ps_accounts.php on line 33
```