### PR TITLE
fix: revert UserTokenRepository

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -74,7 +74,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     strategy:
       matrix:
-        ps_version: ["1.7.8.10", "8.1.4", "nightly"]
+        ps_version: ["1.7.8.10", "8.1.7", "nightly"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -55,8 +55,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        # @TODO: "1.6.1.24" is temporarily disabled here
-        ps_version: ["1.7.8.10", "8.1.6"]
+        ps_version: ["1.7.8.10", "8.1.7"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ lint: php-cs-fixer php-lint
 docker-lint: docker-php-cs-fixer docker-php-lint
 
 # target: lint-fix (or docker-lint-fix)                        - Automatically fix the linting errors
-.PHONY: lint-fix docker-lint-fix
+.PHONY: lint-fix docker-lint-fix fix
+fix: lint-fix
 lint-fix: php-cs-fixer-fix
 docker-lint-fix: docker-php-cs-fixer-fix
 

--- a/config/common.yml
+++ b/config/common.yml
@@ -22,3 +22,7 @@ services:
   PrestaShop\Module\PsAccounts\Presenter\PsAccountsPresenter:
     class: PrestaShop\Module\PsAccounts\Presenter\PsAccountsPresenter
     public: true
+
+  PrestaShop\Module\PsAccounts\Repository\UserTokenRepository:
+    class: PrestaShop\Module\PsAccounts\Repository\UserTokenRepository
+    public: true

--- a/ps_accounts.php
+++ b/ps_accounts.php
@@ -1,7 +1,5 @@
 <?php
 
-use PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer;
-
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -14,7 +12,7 @@ class Ps_accounts extends Module
     const VERSION = '0.0.0';
 
     /**
-     * @var ServiceContainer
+     * @var \PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer
      */
     private $serviceContainer;
 
@@ -38,7 +36,7 @@ class Ps_accounts extends Module
 
         require_once __DIR__ . '/vendor/autoload.php';
 
-        $this->serviceContainer = new ServiceContainer(
+        $this->serviceContainer = new \PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer(
             (string) $this->name,
             $this->getLocalPath()
         );

--- a/ps_accounts.php
+++ b/ps_accounts.php
@@ -1,5 +1,7 @@
 <?php
 
+use PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -12,7 +14,7 @@ class Ps_accounts extends Module
     const VERSION = '0.0.0';
 
     /**
-     * @var \PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer
+     * @var ServiceContainer
      */
     private $serviceContainer;
 
@@ -36,7 +38,7 @@ class Ps_accounts extends Module
 
         require_once __DIR__ . '/vendor/autoload.php';
 
-        $this->serviceContainer = new \PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer(
+        $this->serviceContainer = new ServiceContainer(
             (string) $this->name,
             $this->getLocalPath()
         );

--- a/src/Repository/UserTokenRepository.php
+++ b/src/Repository/UserTokenRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PrestaShop\Module\PsAccounts\Repository;
+
+class UserTokenRepository
+{
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrRefreshToken()
+    {
+    	return 'token';
+    } 
+}

--- a/src/Repository/UserTokenRepository.php
+++ b/src/Repository/UserTokenRepository.php
@@ -13,6 +13,6 @@ class UserTokenRepository
      */
     public function getOrRefreshToken()
     {
-    	return 'token';
-    } 
+        return 'token';
+    }
 }

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -8,5 +8,5 @@ parameters:
     - identifier: missingType.iterableValue
     - '#Property Ps_accounts::\$serviceContainer has unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer as its type.#'
     - '#Instantiated class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer not found.#'
-    - '#Call to method getService() on an unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer.#'
+    - '#Call to method getService\(\) on an unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer.#'
   level: 9

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:
     - identifier: missingType.iterableValue
-    - '#Property Ps_accounts::$serviceContainer has unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer as its type.#'
+    - '#Property Ps_accounts::\$serviceContainer has unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer as its type.#'
     - '#Instantiated class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer not found.#'
     - '#Call to method getService() on an unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer.#'
   level: 9

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:
     - identifier: missingType.iterableValue
-    - '#Property Ps_accounts::\$serviceContainer has unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer as its type.#'
-    - '#Instantiated class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer not found.#'
-    - '#Call to method getService\(\) on an unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer.#'
+    - '#Property Ps_accounts::\$serviceContainer has unknown class PrestaShop\\ModuleLibServiceContainer\\DependencyInjection\\ServiceContainer as its type.#'
+    - '#Instantiated class PrestaShop\\ModuleLibServiceContainer\\DependencyInjection\\ServiceContainer not found.#'
+    - '#Call to method getService\(\) on an unknown class PrestaShop\\ModuleLibServiceContainer\\DependencyInjection\\ServiceContainer.#'
   level: 9

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -6,4 +6,7 @@ parameters:
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:
     - identifier: missingType.iterableValue
+    - '#Property Ps_accounts::$serviceContainer has unknown class#'
+    - '#Instantiated class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer not found.#'
+    - '#Call to method getService() on an unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer.#'
   level: 9

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:
     - identifier: missingType.iterableValue
-    - '#Property Ps_accounts::$serviceContainer has unknown class#'
+    - '#Property Ps_accounts::$serviceContainer has unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer as its type.#'
     - '#Instantiated class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer not found.#'
     - '#Call to method getService() on an unknown class PrestaShop\ModuleLibServiceContainer\DependencyInjection\ServiceContainer.#'
   level: 9


### PR DESCRIPTION
I did deleted this class just as I expected it to be unused.
I was correct, this is unused outside of PS Accounts itself. But updating the original PS Accounts to the Mock is failing due to bad symfony cache management by PrestaShop Core.

This is the reason I'm reverting this change with this PR.